### PR TITLE
Adding a "name" argument to initialize dbus with custom ProductName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ right commandline arguments, ie. as a minimum the right serial port:
   -b, --baud
    The baud rate of the serial port.
    When omitted the baud rate is set to 4800.
+   
+	-n, --name
+	 The product name of the GPS device.  Default is 'NMEA-0183 GPS'.
 
 COMMON OPTIONS:
 

--- a/software/inc/dev_reg.h
+++ b/software/inc/dev_reg.h
@@ -7,6 +7,7 @@ typedef struct
 {
 	un32 timeOut;
 	un32 baudRate;
+	VeStr name;
 } DevReg;
 
 extern DevReg devReg;

--- a/software/src/platform/pc/console.c
+++ b/software/src/platform/pc/console.c
@@ -15,13 +15,15 @@
 DevReg devReg =
 {
 	0,		// Timeout
-	4800	// Baudrate
+	4800,	// Baudrate
+	"NMEA-0183 GPS" // Product name
 };
 
 struct option consoleOptions[] =
 {
 	{"timeout",			required_argument,	0,							't'},
 	{"baud",			required_argument,	0,							'b'},
+	{"name",			required_argument,	0,							'n'},
 	{0,					0,					0,							0}
 };
 
@@ -36,6 +38,9 @@ void consoleUsage(char* program)
 	printf("  -b, --baud\n");
 	printf("   The baud rate of the serial port.\n");
 	printf("   When omitted the baud rate is set to 4800.\n");
+	printf("\n");
+	printf("  -n, --name\n");
+	printf("   The product name of the GPS device. Default is 'NMEA-0183 GPS'.\n");
 	printf("\n");
 	pltOptionsUsage();
 	printf("Victron Energy B.V.\n");
@@ -58,6 +63,14 @@ veBool consoleOption(int flag)
 		devReg.baudRate = veArgInt(optarg);
 		if (errno == EINVAL) {
 			logE(MODULE, "wrong baud rate argument");
+			pltExit(128);
+		}
+		break;
+	case 'n':
+		errno = 0;
+		devReg.name = veArgStr(optarg);
+		if (errno == EINVAL) {
+			logE(MODULE, "wrong name argument");
 			pltExit(128);
 		}
 	}

--- a/software/src/values_dbus_service.c
+++ b/software/src/values_dbus_service.c
@@ -63,7 +63,7 @@ void valuesInit(void)
 	veItemCreateBasic(&root, "Mgmt/Connection", veVariantStr(&v, "USB"));
 	veItemCreateProductId(&root, VE_PROD_ID_NMEA_0183_GPS);
 
-	veStrNewFormat(&s, "NMEA-0183 GPS (%s)", serialPortShort());
+	veStrNewFormat(&s, "%s (%s)", devReg.name, serialPortShort());
 	veItemCreateBasic(&root, "ProductName", veVariantHeapStr(&v, veStrCStr(&s)));
 }
 


### PR DESCRIPTION
The argument should be optional.

As velib is not opensource, I can not build and test this PR.
As I suggested on ble-sensor repo, I think a GitHub action build, eventually limited to white listed users, would be great so that we can build and tests PRs on velib based projects.